### PR TITLE
Fix AvroSerializer usage

### DIFF
--- a/kafka_framework/serialization/avro.py
+++ b/kafka_framework/serialization/avro.py
@@ -3,6 +3,7 @@ Avro serializer implementation.
 """
 
 import json
+from io import BytesIO
 from typing import Any
 
 try:
@@ -42,11 +43,14 @@ class AvroSerializer(BaseSerializer):
         value: Any,
     ) -> bytes:
         """Serialize a value to Avro bytes."""
-        return fastavro.schemaless_writer(value, self.parsed_schema)
+        out = BytesIO()
+        fastavro.schemaless_writer(out, self.parsed_schema, value)
+        return out.getvalue()
 
     async def deserialize(
         self,
         value: bytes,
     ) -> Any:
         """Deserialize Avro bytes to a value."""
-        return fastavro.schemaless_reader(value, self.parsed_schema)
+        out = BytesIO(value)
+        return fastavro.schemaless_reader(out, self.parsed_schema)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,15 @@
+import pytest
+
+from kafka_framework.serialization.avro import AvroSerializer
+
+fastavro = pytest.importorskip("fastavro")
+
+
+@pytest.mark.asyncio
+async def test_avro_roundtrip():
+    schema = {"type": "record", "name": "Test", "fields": [{"name": "field", "type": "string"}]}
+    serializer = AvroSerializer(schema_registry_url="http://localhost", schema_dict=schema)
+    value = {"field": "value"}
+    data = await serializer.serialize(value)
+    result = await serializer.deserialize(data)
+    assert result == value


### PR DESCRIPTION
## Summary
- use BytesIO with `fastavro.schemaless_writer`/`schemaless_reader`
- add a roundtrip test for Avro serialization

## Testing
- `ruff check --fix kafka_framework/serialization/avro.py tests/test_serialization.py`
- `ruff format kafka_framework/serialization/avro.py tests/test_serialization.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiokafka')*

------
https://chatgpt.com/codex/tasks/task_e_688ba90f82e88320b8f257ddae8d041e